### PR TITLE
fix: correct async build result and rework to ES6

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,112 +1,87 @@
-var fs = require('fs');
-var crypto = require('crypto');
-var path = require('path');
-var https = require('https');
-var http = require('http');
-var qs = require('querystring');
-var zlib = require('zlib');
+const fs = require('fs');
+const crypto = require('crypto');
+const path = require('path');
+const https = require('https');
+const http = require('http');
+const qs = require('querystring');
+const zlib = require('zlib');
 
-var plantUml = require('./plantuml_encode');
-
-var options = {
-	"umlPath": "assets/images/uml",
-	"type": "plantuml-service",
-	"host": "plantuml-service.herokuapp.com",
-	"protocol": "https",
-	"path": "/svg/",
-	"blockRegex": "^```uml((.*[\r\n])+?)?```$"
-}
+const plantUml = require('./plantuml_encode');
 
 require('shelljs/global');
 
+let options;
 
-function plantumlServerEscape(block) {
-	//UTF8
-	var toDeflate = unescape(encodeURIComponent(block));
-	var deflated = zlib.deflateRawSync(toDeflate, { level: 9 });
-	return plantUml.encode64(deflated);
-}
+const plantumlServerEscape = (block) => {
+  //UTF8
+  const toDeflate = unescape(encodeURIComponent(block));
+  const deflated = zlib.deflateRawSync(toDeflate, {level: 9});
+  return plantUml.encode64(deflated);
+};
+
+const createUML = async (content, uml, output) => {
+  const svgTag = `![](/${uml.svgPath});`
+  content = content.replace(uml.rawBlock, svgTag);
+  await output.hasFile(uml.svgPath).then(exists => {
+    if (!exists) {
+      return new Promise(resolve => {
+        const client = options.protocol === 'https' ? https : http;
+
+        let path = options.path + qs.escape(uml.umlBlock);
+        if (options.type === 'plantuml-server') {
+          path = options.path + plantumlServerEscape(uml.umlBlock);
+        }
+
+        client.request({host: options.host, path: path}, res => {
+          const ws = fs.createWriteStream(output.resolve(uml.svgPath));
+          res.pipe(ws);
+          res.on('end', resolve);
+        }).end();
+      });
+    }
+  });
+  return content;
+};
 
 module.exports = {
-	hooks: {
-		"init": function () {
-			var output = this.output;
-			var config = this.config.values.pluginsConfig["plantuml-cloud"];
-			if (config.umlPath != undefined) {
-				options.umlPath = config.umlPath;
-			}
-			if (config.type != undefined) {
-				options.type = config.type;
-			}
-			if (config.host != undefined) {
-				options.host = config.host;
-			}
-			if (config.protocol != undefined) {
-				options.protocol = config.protocol;
-			}
-			if (config.path != undefined) {
-				options.path = config.path;
-			}
-			if (config.blockRegex != undefined) {
-				options.blockRegex = config.blockRegex;
-			}
-			var umlPath = output.resolve(options.umlPath);
-			mkdir('-p', umlPath);
-		},
-		"page:before": function (page) {
-			var output = this.output;
-			var content = page.content;
+  hooks: {
+    'init': function() {
+      const output = this.output;
+      const config = this.config.values.pluginsConfig['plantuml-cloud'];
+      options = {
+        umlPath:  config.umlPath || 'assets/images/uml',
+        type: config.type || 'plantuml-service',
+        host: config.host || 'plantuml-service.herokuapp.com',
+        protocol: config.protocol ||'https',
+        path: config.path || '/svg/',
+        blockRegex: config.blockRegex || '^```uml((.*[\r\n])+?)?```$'
+      };
+      const umlPath = output.resolve(options.umlPath);
+      mkdir('-p', umlPath);
+    },
+    'page:before': async function(page) {
+      let content = page.content;
+      const output = this.output;
+      
+      const umls = [];
+      const re = new RegExp(options.blockRegex, 'img');
 
-			var umls = [];
-			var re = new RegExp(options.blockRegex, 'img');
+      while (match = re.exec(content)) {
+        const rawBlock = match[0];
+        const umlBlock = match[1];
+        const md5 = crypto.createHash('md5').update(umlBlock).digest('hex');
+        const svgPath = path.join(options.umlPath, `${md5}.svg`);
+        umls.push({rawBlock, umlBlock,svgPath});
+      }
 
-			while ((match = re.exec(content))) {
-				var rawBlock = match[0];
-				var umlBlock = match[1];
-				var md5 = crypto.createHash('md5').update(umlBlock).digest('hex');
-				var svgPath = path.join(options.umlPath, md5 + '.svg');
-				umls.push({
-					rawBlock: match[0],
-					umlBlock: match[1],
-					svgPath: svgPath
-				});
-			}
+      for (const uml of umls) {
+        content = await createUML(content, uml, output);
+      }
 
-			Promise.all([umls.map(uml => {
-				var svgTag = '![](/' + uml.svgPath + ')';
-				page.content = content = content.replace(uml.rawBlock, svgTag);
-
-				return output.hasFile(uml.svgPath).then(exists => {
-					if (!exists) {
-						return new Promise((resolve, reject) => {
-
-							var client = http;
-							if (options.protocol == "https") {
-								client = https;
-							}
-
-							var path = options.path + qs.escape(uml.umlBlock);
-							if (options.type == "plantuml-server") {
-								path = options.path + plantumlServerEscape(uml.umlBlock);
-							}
-
-							client.request({
-								host: options.host,
-								path: path
-							}, (res) => {
-								var ws = fs.createWriteStream(output.resolve(uml.svgPath));
-								res.pipe(ws);
-								res.on('end', resolve);
-							}).end();
-						});
-					}
-				})
-			})]);
-
-			return page;
-		},
-
-		"page": function (page) { return page; },
-		"page:after": function (page) { return page; }
-	}
+      page.content = content;
+      return page;
+    },
+    'page': page => page,
+    'page:after': page => page
+  }
 };


### PR DESCRIPTION
Due to the promise based execution flow, using
`gitbook build` lead to an empty UML asset folder,
since the program execution finished before generating
the images. This behaviour was corrected by switching to
async functions. The code was also reworked to utilize ES6
features and improve the readability.

Signed-off-by: Daniele Muheim <daniele.muheim@siemens.com>
Reviewed-by: Fabio Huser <fabio.huser@siemens.com>